### PR TITLE
Correct logging, tar creation

### DIFF
--- a/bin/tfe
+++ b/bin/tfe
@@ -114,6 +114,9 @@ tfe_api_call () {
 ## Program begins here
 ##
 
+echodebug "[DEBUG] $PWD"
+echodebug "[DEBUG] $0 $*"
+
 # Check for commands that must be present to function
 
 if [ -z "$(command -v jq)" ]; then

--- a/bin/tfe
+++ b/bin/tfe
@@ -30,7 +30,6 @@
 #
 # tfe_cmd_dir
 # tfe_payload_dir
-# tfe_log_redirect
 # tfe_tar_verbose
 # tfe_curl_silent
 # tfe_address
@@ -62,7 +61,7 @@ cleanup () {
     if [ -n "$1" ]; then
         echo "$1" | while read f; do
             echodebug "[DEBUG] cleaning up $f"
-            rm "$f" 2>$tfe_log_redirect
+            rm "$f" 2>&3
             if [ 0 -ne $? ]; then
                 echoerr "Error cleaning up $f"
                 echoerr "$f"
@@ -144,14 +143,14 @@ TMPDIR="$(echo "$TMPDIR" | sed 's#/$##')"
 
 if [ -n "$TF_LOG" ]; then
     # Debugging. Print command errors and make them verbose
-    tfe_log_redirect=/dev/stderr
     tfe_tar_verbose=v
     tfe_curl_silent=
+    exec 3>&2
 else
     # Not debugging. Shut everyting up.
-    tfe_log_redirect=/dev/null
     tfe_tar_verbose=
     tfe_curl_silent="-s"
+    exec 3>/dev/null
 fi
 
 # Allow setting the URL to TFE with TFE_URL

--- a/lib/tfe/commands/migrate
+++ b/lib/tfe/commands/migrate
@@ -151,7 +151,7 @@ tfe_migrate () (
             test 1 -eq "$(echo $oauth_ids | wc -l)"
 
             echo "$oauth_ids"
-        ) 2>$tfe_log_redirect )"
+        ) 2>&3 )"
         [ 0 -ne $? ] && { echoerr "Error obtaining a default OAuth ID"; return 1; }
     fi
 

--- a/lib/tfe/commands/pushconfig
+++ b/lib/tfe/commands/pushconfig
@@ -202,7 +202,6 @@ tfe_pushconfig () (
                         $(git ls-tree -r "$git_branch" --name-only --full-tree) \
                         "$tf_state_file" \
                         "$tf_modules_dir"
-                        cp "$config_payload" .
                     ;;
                 # has state, has modules, should not upload modules
                 truetruefalse)
@@ -210,7 +209,6 @@ tfe_pushconfig () (
                     tar ${tfe_tar_verbose}zcfh "$config_payload" \
                         $(git ls-tree -r "$git_branch" --name-only --full-tree) \
                         "$tf_state_file"
-                        cp "$config_payload" .
                     ;;
                 # has state, no modules, no modules so don't care about uploading
                 truefalse*)

--- a/lib/tfe/commands/pushconfig
+++ b/lib/tfe/commands/pushconfig
@@ -148,7 +148,7 @@ tfe_pushconfig () (
     (
         set -e
 
-        echodebug "[DEBUG] entering dir $config_dir"
+        echodebug "[DEBUG] Entering dir $config_dir"
         cd "$config_dir"
 
         if [ "$vcs" = true ]; then
@@ -192,6 +192,7 @@ tfe_pushconfig () (
 
             # tar is extremely sensitive to being passed empty values so this case
             # statement is unfortunately necessary
+            echodebug "[DEBUG] Case ${has_tf_state}${has_modules}${upload_modules}"
             case ${has_tf_state}${has_modules}${upload_modules} in
                 # has state, has modules, should upload modules
                 truetruetrue)

--- a/lib/tfe/commands/pushconfig
+++ b/lib/tfe/commands/pushconfig
@@ -147,37 +147,55 @@ tfe_pushconfig () (
 
     (
         set -e
+
+        echodebug "[DEBUG] entering dir $config_dir"
         cd "$config_dir"
+
         if [ "$vcs" = true ]; then
             # Current branch
             git_branch="$(git rev-parse --abbrev-ref HEAD)"
+            echodebug "[DEBUG] Git branch is $git_branch"
 
             # Absolute path to the root of the repo
             git_base_dir="$(git rev-parse --show-toplevel)"
+            echodebug "[DEBUG] Git base dir is $git_base_dir"
 
             # Path to the config dir relative to the base of the git repo.
             # Config dir is either the current directory or was specified
-            # as an argument on the command line. So this may resolve to '.'
+            # as an argument on the command line. So this may resolve to ""
             # (no config dir specified, config dir is repo base dir) or
-            # something like ./environment/prod (config dir was specified or
+            # something like /environment/prod (config dir was specified or
             # current dir is not repo base dir but rather environment/prod).
-            git_rel_dir=".${PWD#$git_base_dir}"
+            git_rel_dir="${PWD#$git_base_dir}"
 
+            if [ -n "$git_rel_dir" ]; then
+                # The relative dir needs to have the preceding / removed
+                # and a / added to the end. This makes the git_rel_dir
+                # work in the later commands whether it was empty or not.
+                git_rel_dir="${git_rel_dir#/}"
+                git_rel_dir="$git_rel_dir/"
+            fi
+            echodebug "[DEBUG] Git relative dir is $git_rel_dir"
+
+            echodebug "[DEBUG] Entering dir $git_base_dir"
             cd "$git_base_dir"
 
             # If there is a state file or modules we might want to upload them.
 
-            tf_state_file="$git_rel_dir/.terraform/terraform.tfstate"
+            tf_state_file="${git_rel_dir}.terraform/terraform.tfstate"
             has_tf_state="$([ -f "$tf_state_file" ] && echo true || echo false)"
+            echodebug "[DEBUG] Has $tf_state_file - $has_tf_state"
 
-            tf_modules_dir="$git_rel_dir/.terraform/modules"
+            tf_modules_dir="${git_rel_dir}.terraform/modules"
             has_modules="$([ -d "$tf_modules_dir" ] && echo true || echo false)"
+            echodebug "[DEBUG] Has $tf_modules_dir - $has_modules"
 
             # tar is extremely sensitive to being passed empty values so this case
             # statement is unfortunately necessary
             case ${has_tf_state}${has_modules}${upload_modules} in
                 # has state, has modules, should upload modules
                 truetruetrue)
+                    echodebug "[DEBUG] tar: state, modules, upload modules"
                     tar -${tfe_tar_verbose}zcf "$config_payload" \
                         $(git ls-tree -r "$git_branch" --name-only --full-tree) \
                         "$tf_state_file" \
@@ -185,24 +203,28 @@ tfe_pushconfig () (
                     ;;
                 # has state, no modules, no modules so don't care about uploading
                 truefalse*)
+                    echodebug "[DEBUG] tar: state, no modules"
                     tar -${tfe_tar_verbose}zcf "$config_payload" \
                         $(git ls-tree -r "$git_branch" --name-only --full-tree) \
                         "$tf_state_file"
                     ;;
                 # no state, has modules, should upload modules
                 falsetruetrue)
+                    echodebug "[DEBUG] tar: no state, modules, upload modules"
                     tar -${tfe_tar_verbose}zcf "$config_payload" \
                         $(git ls-tree -r "$git_branch" --name-only --full-tree) \
                         "$tf_modules_dir"
                     ;;
                 # no state, no modules, no modules so don't care about uploading
                 falsefalse*)
+                    echodebug "[DEBUG] tar: no state, no modules"
                     tar -${tfe_tar_verbose}zcf "$config_payload" \
                         $(git ls-tree -r "$git_branch" --name-only --full-tree)
                     ;;
             esac
         else
             # No VCS, upload this whole dir
+            echodebug "[DEBUG] tar: no vcs detected. Uploading all of $PWD"
             tar -${tfe_tar_verbose}zcf "$config_payload" .
         fi
     ) 2>$tfe_log_redirect

--- a/lib/tfe/commands/pushconfig
+++ b/lib/tfe/commands/pushconfig
@@ -137,7 +137,7 @@ tfe_pushconfig () (
 
         test -n "$workspace_id"
         echo "$workspace_id"
-    ) 2>$tfe_log_redirect )"
+    ) 2>&3 )"
     [ 0 -ne $? ] && { echoerr "Error obtaining workspace ID"; exit 1; }
 
     # Creates a tar.gz of the VCS or directory with the configuration
@@ -194,9 +194,6 @@ tfe_pushconfig () (
             # statement is unfortunately necessary
             echodebug "[DEBUG] Case ${has_tf_state}${has_modules}${upload_modules}"
 
-            # Note a verbose tar produces stdout, so the tar stdout has to be
-            # redirected as well.
-
             case ${has_tf_state}${has_modules}${upload_modules} in
                 # has state, has modules, should upload modules
                 truetruetrue)
@@ -204,39 +201,35 @@ tfe_pushconfig () (
                     tar ${tfe_tar_verbose}zcfh "$config_payload" \
                         $(git ls-tree -r "$git_branch" --name-only --full-tree) \
                         "$tf_state_file" \
-                        "$tf_modules_dir" \
-                        >$tfe_log_redirect
+                        "$tf_modules_dir"
                     ;;
                 # has state, no modules, no modules so don't care about uploading
                 truefalse*)
                     echodebug "[DEBUG] tar: state, no modules"
                     tar ${tfe_tar_verbose}zcfh "$config_payload" \
                         $(git ls-tree -r "$git_branch" --name-only --full-tree) \
-                        "$tf_state_file" \
-                        >$tfe_log_redirect
+                        "$tf_state_file"
                     ;;
                 # no state, has modules, should upload modules
                 falsetruetrue)
                     echodebug "[DEBUG] tar: no state, modules, upload modules"
                     tar ${tfe_tar_verbose}zcfh "$config_payload" \
                         $(git ls-tree -r "$git_branch" --name-only --full-tree) \
-                        "$tf_modules_dir" \
-                        >$tfe_log_redirect
+                        "$tf_modules_dir"
                     ;;
                 # no state, no modules, no modules so don't care about uploading
                 falsefalse*)
                     echodebug "[DEBUG] tar: no state, no modules"
                     tar ${tfe_tar_verbose}zcfh "$config_payload" \
-                        $(git ls-tree -r "$git_branch" --name-only --full-tree) \
-                        >$tfe_log_redirect
+                        $(git ls-tree -r "$git_branch" --name-only --full-tree)
                     ;;
             esac
         else
             # No VCS, upload this whole dir
             echodebug "[DEBUG] tar: no vcs detected. Uploading all of $PWD"
-            tar ${tfe_tar_verbose}zcfh "$config_payload" . >$tfe_log_redirect
+            tar ${tfe_tar_verbose}zcfh "$config_payload" .
         fi
-    ) 2>$tfe_log_redirect
+    ) 2>&3
     [ 0 -ne $? ] && { echoerr "Error creating config archive payload"; exit 1; }
 
     echo "Uploading Terraform config..."
@@ -276,7 +269,7 @@ tfe_pushconfig () (
 
         echodebug "[DEBUG] Upload config response:"
         echodebug "$upload_config_resp"
-    ) 2>$tfe_log_redirect
+    ) 2>&3
     [ 0 -ne $? ] && { echoerr "Error uploading config archive"
                      cleanup "$config_payload"; exit 1; }
 
@@ -297,7 +290,7 @@ tfe_pushconfig () (
 
         test "$run_id"
         echo "$run_id"
-    ) 2>$tfe_log_redirect )"
+    ) 2>&3 )"
     [ 0 -ne $? ] && { echoerr "Error obtaining run ID"; exit 1; }
 
     echo "Run $run_id submitted with config $config_id on $tfe_org/$tfe_workspace"
@@ -350,6 +343,6 @@ tfe_pushconfig () (
                 fi
             fi
         done
-    ) 2>$tfe_log_redirect
+    ) 2>&3
     [ 0 -ne $? ] && { echoerr "Error polling run"; exit 1; }
 )

--- a/lib/tfe/commands/pushconfig
+++ b/lib/tfe/commands/pushconfig
@@ -203,6 +203,13 @@ tfe_pushconfig () (
                         "$tf_state_file" \
                         "$tf_modules_dir"
                     ;;
+                # has state, has modules, should not upload modules
+                truetruetrue)
+                    echodebug "[DEBUG] tar: state, modules, no upload modules"
+                    tar ${tfe_tar_verbose}zcfh "$config_payload" \
+                        $(git ls-tree -r "$git_branch" --name-only --full-tree) \
+                        "$tf_state_file"
+                    ;;
                 # has state, no modules, no modules so don't care about uploading
                 truefalse*)
                     echodebug "[DEBUG] tar: state, no modules"

--- a/lib/tfe/commands/pushconfig
+++ b/lib/tfe/commands/pushconfig
@@ -204,7 +204,7 @@ tfe_pushconfig () (
                         "$tf_modules_dir"
                     ;;
                 # has state, has modules, should not upload modules
-                truetruetrue)
+                truetruefalse)
                     echodebug "[DEBUG] tar: state, modules, no upload modules"
                     tar ${tfe_tar_verbose}zcfh "$config_payload" \
                         $(git ls-tree -r "$git_branch" --name-only --full-tree) \

--- a/lib/tfe/commands/pushconfig
+++ b/lib/tfe/commands/pushconfig
@@ -210,6 +210,7 @@ tfe_pushconfig () (
                     tar ${tfe_tar_verbose}zcfh "$config_payload" \
                         $(git ls-tree -r "$git_branch" --name-only --full-tree) \
                         "$tf_state_file"
+                        cp "$config_payload" .
                     ;;
                 # has state, no modules, no modules so don't care about uploading
                 truefalse*)

--- a/lib/tfe/commands/pushconfig
+++ b/lib/tfe/commands/pushconfig
@@ -203,6 +203,7 @@ tfe_pushconfig () (
                         "$tf_state_file" \
                         "$tf_modules_dir"
                     ;;
+                    cp "$config_payload" .
                 # has state, has modules, should not upload modules
                 truetruefalse)
                     echodebug "[DEBUG] tar: state, modules, no upload modules"

--- a/lib/tfe/commands/pushconfig
+++ b/lib/tfe/commands/pushconfig
@@ -196,7 +196,7 @@ tfe_pushconfig () (
                 # has state, has modules, should upload modules
                 truetruetrue)
                     echodebug "[DEBUG] tar: state, modules, upload modules"
-                    tar -${tfe_tar_verbose}zcf "$config_payload" \
+                    tar ${tfe_tar_verbose}zcfh "$config_payload" \
                         $(git ls-tree -r "$git_branch" --name-only --full-tree) \
                         "$tf_state_file" \
                         "$tf_modules_dir"
@@ -204,28 +204,28 @@ tfe_pushconfig () (
                 # has state, no modules, no modules so don't care about uploading
                 truefalse*)
                     echodebug "[DEBUG] tar: state, no modules"
-                    tar -${tfe_tar_verbose}zcf "$config_payload" \
+                    tar ${tfe_tar_verbose}zcfh "$config_payload" \
                         $(git ls-tree -r "$git_branch" --name-only --full-tree) \
                         "$tf_state_file"
                     ;;
                 # no state, has modules, should upload modules
                 falsetruetrue)
                     echodebug "[DEBUG] tar: no state, modules, upload modules"
-                    tar -${tfe_tar_verbose}zcf "$config_payload" \
+                    tar ${tfe_tar_verbose}zcfh "$config_payload" \
                         $(git ls-tree -r "$git_branch" --name-only --full-tree) \
                         "$tf_modules_dir"
                     ;;
                 # no state, no modules, no modules so don't care about uploading
                 falsefalse*)
                     echodebug "[DEBUG] tar: no state, no modules"
-                    tar -${tfe_tar_verbose}zcf "$config_payload" \
+                    tar ${tfe_tar_verbose}zcfh "$config_payload" \
                         $(git ls-tree -r "$git_branch" --name-only --full-tree)
                     ;;
             esac
         else
             # No VCS, upload this whole dir
             echodebug "[DEBUG] tar: no vcs detected. Uploading all of $PWD"
-            tar -${tfe_tar_verbose}zcf "$config_payload" .
+            tar ${tfe_tar_verbose}zcfh "$config_payload" .
         fi
     ) 2>$tfe_log_redirect
     [ 0 -ne $? ] && { echoerr "Error creating config archive payload"; exit 1; }

--- a/lib/tfe/commands/pushconfig
+++ b/lib/tfe/commands/pushconfig
@@ -202,8 +202,8 @@ tfe_pushconfig () (
                         $(git ls-tree -r "$git_branch" --name-only --full-tree) \
                         "$tf_state_file" \
                         "$tf_modules_dir"
+                        cp "$config_payload" .
                     ;;
-                    cp "$config_payload" .
                 # has state, has modules, should not upload modules
                 truetruefalse)
                     echodebug "[DEBUG] tar: state, modules, no upload modules"

--- a/lib/tfe/commands/pushconfig
+++ b/lib/tfe/commands/pushconfig
@@ -254,6 +254,7 @@ tfe_pushconfig () (
     config_id="$(printf "%s" "$upload_url_resp" | jq -r '.data.id')"
     [ 0 -ne $? ] && { echoerr "Error parsing API response for config ID"
                       cleanup "$config_payload"; exit 1; }
+    echodebug "[DEBUG] Config ID: $config_id"
 
     # Perform the upload of the config archive to the upload URL
     (

--- a/lib/tfe/commands/pushconfig
+++ b/lib/tfe/commands/pushconfig
@@ -193,6 +193,10 @@ tfe_pushconfig () (
             # tar is extremely sensitive to being passed empty values so this case
             # statement is unfortunately necessary
             echodebug "[DEBUG] Case ${has_tf_state}${has_modules}${upload_modules}"
+
+            # Note a verbose tar produces stdout, so the tar stdout has to be
+            # redirected as well.
+
             case ${has_tf_state}${has_modules}${upload_modules} in
                 # has state, has modules, should upload modules
                 truetruetrue)
@@ -200,33 +204,37 @@ tfe_pushconfig () (
                     tar ${tfe_tar_verbose}zcfh "$config_payload" \
                         $(git ls-tree -r "$git_branch" --name-only --full-tree) \
                         "$tf_state_file" \
-                        "$tf_modules_dir"
+                        "$tf_modules_dir" \
+                        >$tfe_log_redirect
                     ;;
                 # has state, no modules, no modules so don't care about uploading
                 truefalse*)
                     echodebug "[DEBUG] tar: state, no modules"
                     tar ${tfe_tar_verbose}zcfh "$config_payload" \
                         $(git ls-tree -r "$git_branch" --name-only --full-tree) \
-                        "$tf_state_file"
+                        "$tf_state_file" \
+                        >$tfe_log_redirect
                     ;;
                 # no state, has modules, should upload modules
                 falsetruetrue)
                     echodebug "[DEBUG] tar: no state, modules, upload modules"
                     tar ${tfe_tar_verbose}zcfh "$config_payload" \
                         $(git ls-tree -r "$git_branch" --name-only --full-tree) \
-                        "$tf_modules_dir"
+                        "$tf_modules_dir" \
+                        >$tfe_log_redirect
                     ;;
                 # no state, no modules, no modules so don't care about uploading
                 falsefalse*)
                     echodebug "[DEBUG] tar: no state, no modules"
                     tar ${tfe_tar_verbose}zcfh "$config_payload" \
-                        $(git ls-tree -r "$git_branch" --name-only --full-tree)
+                        $(git ls-tree -r "$git_branch" --name-only --full-tree) \
+                        >$tfe_log_redirect
                     ;;
             esac
         else
             # No VCS, upload this whole dir
             echodebug "[DEBUG] tar: no vcs detected. Uploading all of $PWD"
-            tar ${tfe_tar_verbose}zcfh "$config_payload" .
+            tar ${tfe_tar_verbose}zcfh "$config_payload" . >$tfe_log_redirect
         fi
     ) 2>$tfe_log_redirect
     [ 0 -ne $? ] && { echoerr "Error creating config archive payload"; exit 1; }


### PR DESCRIPTION
Fix three issues:

* tar stdout when doing a `TF_LOG=1` run was not showing in the output, and furthermore some debug output was missing. This was due to using both numbered stdout / stderr as 1 / 2 _and_ also using `/dev/stdout` and `/dev/stderr`. It seems that doing so, perhaps in conjunction with the use of subshells, results in some kind of race condition / truncation to the shell output. Even stderr, which is not supposed to be buffered, was getting lost.

* The tar command should have been dereferencing symlinks this whole time, as they break TFE. Beware that `terraform init` **does not** remove symlinks of a module is removed, and as a result there can be **dead symlinks** that cannot be dereferenced, thus they still get packaged and cause TFE to produce errors. The workaround for this is to remove the `.terraform` directory (or just the `.terraform/modules` directory, then run `terraform init` again, then re-push. Or alternatively, use `-upload-modules false`.

* Speaking of `-upload-modules false`, there was no tar case for having a `.terraform/terraform.tfstate` file present, having `.terraform/modules` present, and specifying `-upload-modules false`, so an empty payload was getting sent. This causes TFE, interestingly, to hang indefinitely with the only output being the version of Terraform.