### PR TITLE
Fixing syntax error in dev branch pushvars

### DIFF
--- a/lib/tfe/commands/pushvars
+++ b/lib/tfe/commands/pushvars
@@ -667,7 +667,7 @@ tfe_pushvars () (
                     in_var = 0
                     in_value = 0
                 }
-            }' "$(basename $var_file)")"
+            }' "$(basename "$var_file"))"
     fi
 
     echodebug "[DEBUG] All variables:"

--- a/lib/tfe/commands/pushvars
+++ b/lib/tfe/commands/pushvars
@@ -667,7 +667,7 @@ tfe_pushvars () (
                     in_var = 0
                     in_value = 0
                 }
-            }' "$(basename $var_file"))"
+            }' "$(basename $var_file)")"
     fi
 
     echodebug "[DEBUG] All variables:"


### PR DESCRIPTION
Ran into this while testing. This should fix the syntax error.

../.cli/tfe-cli/bin/tfe: 671: /home/circleci/project/.ci/deploy/.cli/tfe-cli/lib/tfe/commands/pushvars: Syntax error: "fi" unexpected (expecting ")")
