### PR TITLE
Gem token descriptor missing from README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ We recommend keeping these scripts up to date by regularly running `git pull`.
 
 ## Actions
 
-This repository includes three subcommands:
+This repository includes three subcommands, all of which require the `TFE_TOKEN` env variable to be set to a valid TFE token for authentication.  One can be generated from within TFE as described here: https://www.terraform.io/docs/enterprise/api/organization-tokens.html.
 
 - `tfe pushconfig` — Upload a Terraform configuration to a workspace and begin
   a run.


### PR DESCRIPTION
I found it odd that basic usage doesn't start with authentication.  Is there another way to auth to TFE?  Maybe a breakdown should be provided as this seems to be the official doc for now.  Great tool.