### PR TITLE
poll on config status before creating run

### DIFF
--- a/lib/tfe/commands/pushconfig
+++ b/lib/tfe/commands/pushconfig
@@ -436,6 +436,28 @@ tfe_pushconfig () (
         cleanup "$config_payload" "$tarlist"
     fi
 
+    # Submission of the config version and upload of the archive does not mean
+    # that the config version is ready for use. It has a status, and it's
+    # necessary to poll on that status to make sure that the upload is
+    # "uploaded", even if the upload is complete on the client side.
+    url="$tfe_address/api/v2/configuration-versions/$config_id"
+    config_status=
+    retries=0
+    while [ "$config_status" != "uploaded" ] && [ $retries -lt 3 ]; do
+        # Initially don't sleep, and then back off linearly
+        sleep $retries
+        if config_get_resp="$(tfe_api_call $url)"; then
+            config_status="$(printf "%s" "$config_get_resp" | jq -r '.data.attributes.status')"
+        fi
+        echodebug "[DEBUG] Config status: $config_status"
+        retries=$(( $retries + 1 ))
+    done
+
+    if [ "$config_status" != "uploaded" ]; then
+        echoerr "Error creating run. Config status is $config_status after $retries tries"
+        return 1
+    fi
+
     make_run_payload "$destroy" "$message" "$config_id" "$workspace_id"
     echodebug "[DEBUG] Run payload contents:"
     echodebug "$(cat "$run_payload")"


### PR DESCRIPTION
Resolves #42

Pasting the code comments:

```
    # Submission of the config version and upload of the archive does not mean
    # that the config version is ready for use. It has a status, and it's
    # necessary to poll on that status to make sure that the upload is
    # "uploaded", even if the upload is complete on the client side.
```

To demonstrate, I added a echo "$retries $config_status" line and did 10 runs:

```
$ for i in {1..10}; do tfe pushconfig; done
Uploading Terraform config...
0 uploaded
Run run-SrSg9oqgkvmavmmh submitted to brentwoodruff/just_null using config cv-PDpTgvVqaubRHEdT
Uploading Terraform config...
0 pending
1 pending
2 uploaded
Run run-7fbWGis4QWGuFJFC submitted to brentwoodruff/just_null using config cv-2uH1VkioFTJiigAB
Uploading Terraform config...
0 uploaded
Run run-hD79XxdKaSphw5Vq submitted to brentwoodruff/just_null using config cv-ohCEj1sL92Rkb8iV
Uploading Terraform config...
0 uploaded
Run run-Z2xaeNJJQBCi8jtV submitted to brentwoodruff/just_null using config cv-fsYF92hYe1dvn4ug
Uploading Terraform config...
0 uploaded
Run run-s2cEzqQhDm1Aj6a2 submitted to brentwoodruff/just_null using config cv-UbrTxHgGyo6LCSnj
Uploading Terraform config...
0 uploaded
Run run-RHuBXYs8NCX3ztgM submitted to brentwoodruff/just_null using config cv-vynMHyWFhX7w7jjz
Uploading Terraform config...
0 uploaded
Run run-BrCTqnoh1U3U29uD submitted to brentwoodruff/just_null using config cv-CkZH2N39fBt6GEu1
Uploading Terraform config...
0 uploaded
Run run-QjRAM2jUAZiVqgnU submitted to brentwoodruff/just_null using config cv-vtBg3kVpmRbf1u7Z
Uploading Terraform config...
0 pending
1 uploaded
Run run-kctqPFvD7gQ7vdKy submitted to brentwoodruff/just_null using config cv-HB7xpy51n54tYQxa
Uploading Terraform config...
0 uploaded
Run run-zfyu2CHEuQ3jVHGT submitted to brentwoodruff/just_null using config cv-X9aTohDsyoYaNPJb
```

Out of 10 runs in a loop, 1 needed 2 retries and 1 needed 1 retry. Everything I've tried has been able to make it with the current setup. To be sure the error condition worked, I lowered the retry max to 1 and removed the sleep.

```
Uploading Terraform config...
Error creating run. Config status is pending after 1 retries
```